### PR TITLE
 passing on an optional argument (...) to qvalue

### DIFF
--- a/R/deSet-methods.R
+++ b/R/deSet-methods.R
@@ -351,7 +351,7 @@ setMethod("apply_jackstraw",
           function(object, r1 = NULL, r = NULL, s = NULL, B = NULL,
                    covariate = NULL, verbose = TRUE, seed = NULL) {
             dat <- exprs(object)
-            js <- jackstraw::jackstraw.PCA(dat, r1 = r1, r = r, s = s, B = B,
+            js <- jackstraw::jackstraw_pca(dat, r1 = r1, r = r, s = s, B = B,
                       covariate = covariate, verbose = verbose, seed = seed)
             return(js)
           })


### PR DESCRIPTION
The S4 method for signature 'deSet,missing' couldn't pass on ... to qvalue